### PR TITLE
Create asset bundle for active build target

### DIFF
--- a/Runtime/Core/GeneralToolkit.cs
+++ b/Runtime/Core/GeneralToolkit.cs
@@ -1495,10 +1495,7 @@ namespace COLIBRIVR
             // Try to build the asset bundles for the current editor's platform.
             try
             {
-                BuildTarget platform = BuildTarget.StandaloneWindows;
-#if UNITY_EDITOR_OSX
-                platform = BuildTarget.StandaloneOSX;
-#endif //UNITY_EDITOR_OSX
+                BuildTarget platform = EditorUserBuildSettings.activeBuildTarget;
                 BuildPipeline.BuildAssetBundles(relativeBundleDirectory, bundles, BuildAssetBundleOptions.None, platform);
                 return true;
             }


### PR DESCRIPTION
`BuildPipeline.BuildAssetBundles` failed on platforms other than Windows and MacOS, notably on Linux.

This minor change selects the platform based on the active build target, as set under 
_File→Build Settings…→Target Platform_