### PR TITLE
Fix disk-blending of per-view meshes on OpenGL

### DIFF
--- a/Shaders/Rendering/DiskBlendedPerViewMeshes.shader
+++ b/Shaders/Rendering/DiskBlendedPerViewMeshes.shader
@@ -67,7 +67,7 @@ Shader "COLIBRIVR/Rendering/DiskBlendedPerViewMeshes"
             {
                 uint sourceCamIndex = UNITY_ACCESS_INSTANCED_PROP(InstanceProperties, _SourceCamIndex);
                 clipXYZW = UnityObjectToClipPos(i.objectXYZW);
-                float normalizedDeviceZ = saturate(clipXYZW.z / clipXYZW.w);
+                float normalizedDeviceZ = clipXYZW.z / clipXYZW.w;
                 clipXYZW.z = clipXYZW.w * ScaleNormalizedDeviceZ(sourceCamIndex, normalizedDeviceZ);
                 draw_v2f o;
                 o.sourceCamIndex = sourceCamIndex;


### PR DESCRIPTION
Fixes problems that prevent correct disk-based blending on OpenGL
platforms.

Direct3D and OpenGL use different conventions for the range of
the z-coordinate in normalised device coordinates as well as for
the encoding of depth buffer values (see [Platform-specific rendering differences](https://docs.unity3d.com/2019.3/Documentation/Manual/SL-PlatformDifferences.html)).

In particular, the NDC z-range is [0,1] and [-1,1] in D3D and
OpenGL, respectively.
Also, raw depth buffer values in D3D are reversed, i.e. values range
from 1(=near) to 0(=far), whereas OpenGL uses 0(=near) to 1(=far).

While many Unity macros and shader helper functions seem to abstract
these differences away, this does cause problems in certain places.
Notably on OpenGL platforms, `UnityObjectToClipPos` yields negative
z-values close to the near clipping plane, and sampling high-precision
depth textures produces raw values that increase with depth.

This commit adds checks to make NDC z-scaling and depth testing
work equally on OpenGL and Direct3D.