### PR TITLE
Fix disocclusion triangle rendering

### DIFF
--- a/Runtime/Rendering/TexturedPerViewMeshes.cs
+++ b/Runtime/Rendering/TexturedPerViewMeshes.cs
@@ -114,7 +114,7 @@ namespace COLIBRIVR.Rendering
         /// <summary>
         /// Assigns the blending material to each focal surface.
         /// </summary>
-        private void AssignMaterialToGeometricProxy()
+        private protected virtual void AssignMaterialToGeometricProxy()
         {
             MaterialPropertyBlock properties = new MaterialPropertyBlock();
             for(int sourceCamIndex = 0; sourceCamIndex < PMPerViewMeshesQSTR.perViewMeshTransforms.Length; sourceCamIndex++)

--- a/Runtime/Rendering/TexturedPerViewMeshesDT.cs
+++ b/Runtime/Rendering/TexturedPerViewMeshesDT.cs
@@ -111,6 +111,21 @@ namespace COLIBRIVR.Rendering
             blendingMaterial = new Material(GeneralToolkit.shaderRenderingTexturedPerViewMeshesDT);
         }
 
+        /// <inheritdoc/>
+        private protected override void AssignMaterialToGeometricProxy()
+        {
+            MaterialPropertyBlock properties = new MaterialPropertyBlock();
+            for(int sourceCamIndex = 0; sourceCamIndex < PMPerViewMeshesQSTR.perViewMeshTransforms.Length; sourceCamIndex++)
+            {
+                MeshRenderer meshRenderer = PMPerViewMeshesQSTR.perViewMeshTransforms[sourceCamIndex].gameObject.AddComponent<MeshRenderer>();
+                meshRenderer.material = blendingMaterial;
+                properties.SetFloat(_shaderNameSourceCamIndex, sourceCamIndex);
+                properties.SetVector(_shaderNameSourceCamPosXYZ, PMPerViewMeshesQSTR.perViewMeshTransforms[sourceCamIndex].position);
+                meshRenderer.SetPropertyBlock(properties);
+            }
+        }
+
+
 #endregion //INHERITANCE_METHODS
 
 #region METHODS

--- a/Shaders/Rendering/TexturedPerViewMeshesDT.shader
+++ b/Shaders/Rendering/TexturedPerViewMeshesDT.shader
@@ -18,6 +18,7 @@ Shader "COLIBRIVR/Rendering/TexturedPerViewMeshesDT"
         _UseDebugColor ("Whether to use the debug color to mark disocclusion triangles", int) = 0
         _MipMapLevel ("The mip map level to use for blurring disocclusion triangles", int) = 0
         [PerRendererData] _SourceCamIndex ("Source camera index", int) = 0
+        [PerRendererData] _SourceCamPosXYZ ("Source camera position", Vector) = (0, 0, 0)
     }
     SubShader
     {
@@ -62,6 +63,7 @@ Shader "COLIBRIVR/Rendering/TexturedPerViewMeshesDT"
             UNITY_DECLARE_TEX2DARRAY(_ColorData);
             UNITY_INSTANCING_BUFFER_START(InstanceProperties)
                 UNITY_DEFINE_INSTANCED_PROP(int, _SourceCamIndex)
+                UNITY_DEFINE_INSTANCED_PROP(float3, _SourceCamPosXYZ)
             UNITY_INSTANCING_BUFFER_END(InstanceProperties)
             float _OrthogonalityParameter;
             float _TriangleSizeParameter;
@@ -89,7 +91,7 @@ Shader "COLIBRIVR/Rendering/TexturedPerViewMeshesDT"
     {
         float3 triangleCenter = (vertex0 + vertex1 + vertex2) / 3.0;
         float3 triangleNormal = normalize(cross(vertex2 - vertex0, vertex1 - vertex0));
-        float3 normalizedFrameCamToTriangle = normalize(triangleCenter - 0);
+        float3 normalizedFrameCamToTriangle = normalize(triangleCenter - _SourceCamPosXYZ);
         bool orthogonalityCheck = abs(dot(triangleNormal, normalizedFrameCamToTriangle)) < _OrthogonalityParameter;
         if(orthogonalityCheck)
         {


### PR DESCRIPTION
The rubbersheet test computed the angle between a triangle's normal
and its position in word coordinates instead of in the frame of the
respective reference view.

This PR passes the reference view position to the shader and uses it to
transform world to ref. view coordinates.